### PR TITLE
Add support for RectTransform sizeDelta tweening

### DIFF
--- a/Assets/ZestKit/TweenTargets/TweenTargets.cs
+++ b/Assets/ZestKit/TweenTargets/TweenTargets.cs
@@ -709,7 +709,32 @@ namespace Prime31.ZestKit
 	}
 
 
-	public class ScrollRectNormalizedPositionTarget : AbstractTweenTarget<ScrollRect,Vector2>
+    public class RectTransformSizeDeltaTarget : AbstractTweenTarget<RectTransform, Vector2>
+    {
+        public override void setTweenedValue(Vector2 value)
+        {
+            // if the babysitter is enabled and we dont validate just silently do nothing
+            if (ZestKit.enableBabysitter && !validateTarget())
+                return;
+
+            _target.sizeDelta = value;
+        }
+
+
+        public override Vector2 getTweenedValue()
+        {
+            return _target.sizeDelta;
+        }
+
+
+        public RectTransformSizeDeltaTarget(RectTransform rectTransform)
+        {
+            _target = rectTransform;
+        }
+    }
+
+
+    public class ScrollRectNormalizedPositionTarget : AbstractTweenTarget<ScrollRect,Vector2>
 	{
 		public override void setTweenedValue( Vector2 value )
 		{

--- a/Assets/ZestKit/ZestKitExtensions.cs
+++ b/Assets/ZestKit/ZestKitExtensions.cs
@@ -538,19 +538,36 @@ namespace Prime31.ZestKit
 			return tween;
 		}
 
-		#endregion
 
-
-		#region ScrollRect tweens
-
-		/// <summary>
-		/// tweens the ScrollRects normalizedPosition (scroll position)
+        /// <summary>
+		/// tweens the RectTransforms sizeDelta property
 		/// </summary>
-		/// <returns>The knormalized position to.</returns>
+		/// <returns>The sizeDelta to.</returns>
 		/// <param name="self">Self.</param>
 		/// <param name="to">To.</param>
 		/// <param name="duration">Duration.</param>
-		public static ITween<Vector2> ZKnormalizedPositionTo( this ScrollRect self, Vector2 to, float duration = 0.3f )
+		public static ITween<Vector2> ZKsizeDeltaTo(this RectTransform self, Vector2 to, float duration = 0.3f)
+        {
+            var tweenTarget = new RectTransformSizeDeltaTarget(self);
+            var tween = Vector2Tween.create();
+            tween.initialize(tweenTarget, to, duration);
+
+            return tween;
+        }
+
+        #endregion
+
+
+        #region ScrollRect tweens
+
+        /// <summary>
+        /// tweens the ScrollRects normalizedPosition (scroll position)
+        /// </summary>
+        /// <returns>The knormalized position to.</returns>
+        /// <param name="self">Self.</param>
+        /// <param name="to">To.</param>
+        /// <param name="duration">Duration.</param>
+        public static ITween<Vector2> ZKnormalizedPositionTo( this ScrollRect self, Vector2 to, float duration = 0.3f )
 		{
 			var tweenTarget = new ScrollRectNormalizedPositionTarget( self );
 			var tween = Vector2Tween.create();


### PR DESCRIPTION
ZKsizeDeltaTo can be used to tween RectTransform sizeDelta

example:

``` cs
RectTransform rectTrans;
rectTrans.ZKsizeDeltaTo(new Vector2(400, 400), 2.0f).setLoops(LoopType.PingPong).start();
```
