### PR TITLE
ITween - adds tween offsetting

### DIFF
--- a/Assets/ZestKit/Splines/SplineTween.cs
+++ b/Assets/ZestKit/Splines/SplineTween.cs
@@ -23,7 +23,7 @@ namespace Prime31.ZestKit
 
 		public void setTweenedValue( Vector3 value )
 		{
-			_transform.position = value;
+			_transform.position = value + this._offset;
 		}
 
 
@@ -49,7 +49,7 @@ namespace Prime31.ZestKit
 			if( _isRelativeTween )
 				position += _fromValue;
 
-			setTweenedValue( position );
+			setTweenedValue(position + this._offset);
 		}
 
 

--- a/Assets/ZestKit/TweenTargets/TransformVector3Tween.cs
+++ b/Assets/ZestKit/TweenTargets/TransformVector3Tween.cs
@@ -35,20 +35,20 @@ namespace Prime31.ZestKit
 			switch( _targetType )
 			{
 				case TransformTargetType.Position:
-					_transform.position = value;
+					_transform.position = value + this._offset;
 					break;
 				case TransformTargetType.LocalPosition:
-					_transform.localPosition = value;
+					_transform.localPosition = value + this._offset;
 					break;
 				case TransformTargetType.LocalScale:
-					_transform.localScale = value;
+					_transform.localScale = value + this._offset;
 					break;
 				case TransformTargetType.EulerAngles:
-					_transform.eulerAngles = value;
-					break;
+					_transform.eulerAngles = value + this._offset;
+                    break;
 				case TransformTargetType.LocalEulerAngles:
-					_transform.localEulerAngles = value;
-					break;
+					_transform.localEulerAngles = value + this._offset;
+                    break;
 				default:
 					throw new System.ArgumentOutOfRangeException();
 			}

--- a/Assets/ZestKit/Tweens/ITween.cs
+++ b/Assets/ZestKit/Tweens/ITween.cs
@@ -117,6 +117,15 @@ namespace Prime31.ZestKit
 		/// <returns>The next tween.</returns>
 		/// <param name="nextTween">Next tween.</param>
 		ITween<T> setNextTween( ITweenable nextTween );
+
+        /// <summary>
+        /// Allows to apply any arbitrary value at any time to current tweened value but preserving the tween.
+        /// Can be used for e.g. more advanced tween composition or add noise to otherwise steady nature of tween values.
+        /// When not changed adds T.Zero to tween values.
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        ITween<T> setOffset(T offset);
 	}
 		
 

--- a/Assets/ZestKit/Tweens/Tween.cs
+++ b/Assets/ZestKit/Tweens/Tween.cs
@@ -35,6 +35,7 @@ namespace Prime31.ZestKit
 		protected Action<ITween<T>> _completionHandler;
 		protected Action<ITween<T>> _loopCompleteHandler;
 		protected ITweenable _nextTween;
+        protected T _offset;
 
 		// tween state
 		protected TweenState _tweenState = TweenState.Complete;
@@ -165,6 +166,12 @@ namespace Prime31.ZestKit
 			_nextTween = nextTween;
 			return this;
 		}
+
+        public ITween<T> setOffset( T offset)
+        {
+            this._offset = offset;
+            return this;
+        }
 
 		#endregion
 

--- a/Assets/ZestKit/Tweens/Tweens.cs
+++ b/Assets/ZestKit/Tweens/Tweens.cs
@@ -37,9 +37,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( (int)Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( (int)Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( (int)Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( (int)Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -82,9 +82,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -127,9 +127,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -172,9 +172,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -217,9 +217,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -262,9 +262,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) * this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) * this._offset);
 		}
 
 
@@ -307,9 +307,9 @@ namespace Prime31.ZestKit
 		protected override void updateValue()
 		{
 			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
+				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration) + this._offset);
 		}
 
 
@@ -351,14 +351,25 @@ namespace Prime31.ZestKit
 
 		protected override void updateValue()
 		{
-			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
-			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
-		}
+            Color32 newColor;
+
+            if (_animationCurve != null)
+                newColor = Zest.ease(_animationCurve, _fromValue, _toValue, _elapsedTime, _duration);
+            else
+                newColor = Zest.ease(_easeType, _fromValue, _toValue, _elapsedTime, _duration);
+
+            newColor = new Color32(
+                (byte)(newColor.r + this._offset.r)
+                , (byte)(newColor.g + this._offset.g)
+                , (byte)(newColor.b + this._offset.b)
+                , (byte)(newColor.a + this._offset.a)
+                );
+
+            _target.setTweenedValue(newColor);
+        }
 
 
-		public override void recycleSelf()
+        public override void recycleSelf()
 		{
 			base.recycleSelf();
 
@@ -403,14 +414,20 @@ namespace Prime31.ZestKit
 
 		protected override void updateValue()
 		{
-			if( _animationCurve != null )
-				_target.setTweenedValue( Zest.ease( _animationCurve, _fromValue, _toValue, _elapsedTime, _duration ) );
-			else
-				_target.setTweenedValue( Zest.ease( _easeType, _fromValue, _toValue, _elapsedTime, _duration ) );
-		}
+            Rect newRect;
+
+            if (_animationCurve != null)
+                newRect = Zest.ease(_animationCurve, _fromValue, _toValue, _elapsedTime, _duration);
+            else
+                newRect = Zest.ease(_easeType, _fromValue, _toValue, _elapsedTime, _duration);
+
+            newRect = new Rect(newRect.x + this._offset.x, newRect.y + this._offset.y, newRect.width + this._offset.width, newRect.height + this._offset.height);
+
+            _target.setTweenedValue(newRect);
+        }
 
 
-		public override void recycleSelf()
+        public override void recycleSelf()
 		{
 			base.recycleSelf();
 


### PR DESCRIPTION
This is very simple but rather usable change allowing to dynamically offset tweened values. It's usable when adding some more dynamic behaviour to tweened object by adding e.g. noise, and allows more advanced tween compositions: just implement your own TweenTarget and call setOffset() on original tween in e.g. Update with your target value - the resulting tweening will be additive composition of the original and your target tween.
( the tweened values types should be also the same - 

Only ITween interface is modified in this PR - it should probably be available also on AbstractTweenable and this whole composition thing should be probably more generic / easier to set up to be proper ZestKit 'feature'.

note: not entirely sure about additive properties of Quaternions and Color, Color32, esp. in case of color types adding values should be in proper color space and not simple arithmetic addition.

Feel free to rename/tidy up/change or rip apart :) -- I tried to choose proper level of abstraction but maybe it is doable in a better way.
