### PR TITLE
Clear warnings

### DIFF
--- a/Assets/ZestKit/Splines/SplineAssetUtils.cs
+++ b/Assets/ZestKit/Splines/SplineAssetUtils.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 using System.IO;
+#if ENABLE_UNITYWEBREQUEST
+using UnityEngine.Networking;
+#endif
 
 
 namespace Prime31.ZestKit
@@ -30,10 +33,20 @@ namespace Prime31.ZestKit
 			{
 				path = Path.Combine( "jar:file://" + Application.dataPath + "!/assets/", pathAssetName );
 
+#if ENABLE_UNITYWEBREQUEST
+				UnityWebRequest loadAsset = UnityWebRequest.Get( path );
+				loadAsset.SendWebRequest();
+				while( !loadAsset.isDone ) { } // maybe make a safety check here
+
+				return bytesToVector3List( loadAsset.downloadHandler.data );
+#elif ENABLE_WWW
 				WWW loadAsset = new WWW( path );
 				while( !loadAsset.isDone ) { } // maybe make a safety check here
 
 				return bytesToVector3List( loadAsset.bytes );
+#else
+				throw System.NotImplementedException();
+#endif
 			}
 			else
 			{

--- a/Assets/ZestKitDemo/Demo Scripts/ZestKitSplineDemo.cs
+++ b/Assets/ZestKitDemo/Demo Scripts/ZestKitSplineDemo.cs
@@ -5,10 +5,10 @@ using UnityEngine;
 public class ZestKitSplineDemo : MonoBehaviour
 {
     public Transform quad;
-    [SerializeField] private bool LoadFromScriptableObject;
-    [SerializeField] private ZestSplineSettings FigureEightSplineSettings;
-    [SerializeField] private ZestSplineSettings CircleSplineSettings;
-    [SerializeField] private ZestSplineSettings DemoRouteSplineSettings;
+    [SerializeField] public bool LoadFromScriptableObject;
+    [SerializeField] public ZestSplineSettings FigureEightSplineSettings;
+    [SerializeField] public ZestSplineSettings CircleSplineSettings;
+    [SerializeField] public ZestSplineSettings DemoRouteSplineSettings;
 
     float _duration = 2.5f;
 


### PR DESCRIPTION
- Use UnityWebRequest when possible
- Clean up some 0649 warnings on demos
(see https://issuetracker.unity3d.com/issues/serializedfield-fields-produce-field-is-never-assigned-to-dot-dot-dot-warning)